### PR TITLE
Added share button in event page

### DIFF
--- a/src/app/tab-calendar/page-calendar-event/page-calendar-event.page.html
+++ b/src/app/tab-calendar/page-calendar-event/page-calendar-event.page.html
@@ -4,6 +4,9 @@
       <ion-back-button defaultHref="/"></ion-back-button>
     </ion-buttons>
     <ion-title>Evento</ion-title>
+    <ion-button slot="end" fill="clear" (click)="presentToastShare()"
+      ><ion-icon slot="icon-only" ios="share-outline" md="share-social"></ion-icon
+    ></ion-button>
   </ion-toolbar>
 </ion-header>
 

--- a/src/app/tab-calendar/page-calendar-event/page-calendar-event.page.ts
+++ b/src/app/tab-calendar/page-calendar-event/page-calendar-event.page.ts
@@ -155,7 +155,7 @@ export class PageCalendarEventPage implements OnInit {
   async presentToastShare() {
     const toast = await this.toastController.create({
       header: 'Compartilhar',
-      message: 'Evento copiado para a área de transferência',
+      message: 'Link copiado para a área de transferência',
       icon: 'copy',
       position: 'bottom',
       duration: 2000,

--- a/src/app/tab-calendar/page-calendar-event/page-calendar-event.page.ts
+++ b/src/app/tab-calendar/page-calendar-event/page-calendar-event.page.ts
@@ -152,6 +152,25 @@ export class PageCalendarEventPage implements OnInit {
     toast.present();
   }
 
+  async presentToastShare() {
+    const toast = await this.toastController.create({
+      header: 'Compartilhar',
+      message: 'Evento copiado para a área de transferência',
+      icon: 'copy',
+      position: 'bottom',
+      duration: 2000,
+      buttons: [
+        {
+          side: 'end',
+          text: 'OK',
+          role: 'cancel',
+        },
+      ],
+    });
+    this.clipboardService.copy('https://fct-pp.web.app' + this.router.url);
+    toast.present();
+  }
+
   getEmoji(emoji: string): any {
     if (emoji === undefined) {
       return this.sanitizer.bypassSecurityTrustResourceUrl(parse('❔')[0].url);


### PR DESCRIPTION
Adição de botão na página do evento para copiar na área de transferência o link da página do evento
Ao clicar exibirá uma notificação da confirmação da copia do link do evento

Closes #21 