### PR TITLE
Pilot testing fixes

### DIFF
--- a/src/app/page-profile/page-profile.page.html
+++ b/src/app/page-profile/page-profile.page.html
@@ -27,7 +27,12 @@
       class="qr-code ion-text-center"
       [text]="'uid:' + user.uid"
       [renderAsync]="true"
-      render="svg"
-      fill="'#000'"></ngx-kjua>
+      render="image"
+      ecLevel="H"
+      [minVersion]="7"
+      fill="#000"
+      [size]="320"
+      [quiet]="2"
+      back="#fff"></ngx-kjua>
   </ion-card>
 </ion-content>

--- a/src/app/page-profile/page-profile.page.scss
+++ b/src/app/page-profile/page-profile.page.scss
@@ -1,4 +1,4 @@
 .qr-code {
-  padding: 20px;
+  padding: 20px 10px;
   background-color: #fff;
 }

--- a/src/app/page-restricted-area/attendance/page-scanner/scanner.page.ts
+++ b/src/app/page-restricted-area/attendance/page-scanner/scanner.page.ts
@@ -116,6 +116,7 @@ export class ScannerPage implements OnInit {
   onCodeResult(resultString: string) {
     if (resultString.startsWith('uid:') && resultString.length === 32) {
       resultString = resultString.substring(4);
+      console.log(resultString);
       this.afs
         .collection<attendance>(`events/${this.eventID}/attendance`)
         .doc(resultString)
@@ -188,19 +189,36 @@ export class ScannerPage implements OnInit {
   async toastDuplicate() {
     const toast = await this.toastController.create({
       header: 'Já escaneado',
+      message:
+        'Confira se o nome do usuário está na lista. Se não estiver, confira a sua conexão com a internet e recarregue a página.',
       icon: 'copy',
       position: 'top',
-      duration: 2000,
+      duration: 5000,
+      buttons: [
+        {
+          side: 'end',
+          text: 'OK',
+          role: 'cancel',
+        },
+      ],
     });
     toast.present();
   }
 
   async toastInvalid() {
     const toast = await this.toastController.create({
-      header: 'QR Code incompatível',
+      header: 'QR Code incompatível ou perfil não encontrado no banco de dados',
+      message: 'Solicite que o usuário faça logoff e login novamente ou insira os dados manualmente.',
       icon: 'close-circle',
       position: 'top',
-      duration: 2000,
+      duration: 5000,
+      buttons: [
+        {
+          side: 'end',
+          text: 'OK',
+          role: 'cancel',
+        },
+      ],
     });
     toast.present();
   }

--- a/src/app/shared/services/auth.service.ts
+++ b/src/app/shared/services/auth.service.ts
@@ -73,7 +73,7 @@ export class AuthService {
   async toastLoginFailed() {
     const toast = await this.toastController.create({
       header: 'Houve um erro no seu login',
-      message: 'Por favor, faça login novamente.',
+      message: 'Verifique a sua conexão e faça login novamente.',
       icon: 'close-circle',
       position: 'bottom',
       duration: 5000,

--- a/src/app/shared/services/auth.service.ts
+++ b/src/app/shared/services/auth.service.ts
@@ -5,7 +5,7 @@ import { User } from '../services/user';
 import firebase from 'firebase/compat/app';
 import { AngularFireAuth } from '@angular/fire/compat/auth';
 
-import { ModalController } from '@ionic/angular';
+import { ModalController, ToastController } from '@ionic/angular';
 import { GlobalConstantsService } from './global-constants.service';
 import { AngularFireRemoteConfig } from '@angular/fire/compat/remote-config';
 import { first } from 'rxjs';
@@ -22,7 +22,8 @@ export class AuthService {
     public afs: AngularFirestore,
     public ngZone: NgZone,
     public modalController: ModalController,
-    public remoteConfig: AngularFireRemoteConfig
+    public remoteConfig: AngularFireRemoteConfig,
+    public toastController: ToastController
   ) {
     this.auth.authState.subscribe((user) => {
       if (user) {
@@ -52,7 +53,7 @@ export class AuthService {
         console.log('Signed in');
       })
       .catch((error) => {
-        console.log('error');
+        console.error(error);
       });
   }
 
@@ -63,7 +64,28 @@ export class AuthService {
       this.SetUserData(result.user);
     } catch (error) {
       console.error('Login failed');
+      console.error(error);
+      this.toastLoginFailed();
+      this.SignOut();
     }
+  }
+
+  async toastLoginFailed() {
+    const toast = await this.toastController.create({
+      header: 'Houve um erro no seu login',
+      message: 'Por favor, faça login novamente.',
+      icon: 'close-circle',
+      position: 'bottom',
+      duration: 5000,
+      buttons: [
+        {
+          side: 'end',
+          text: 'OK',
+          role: 'cancel',
+        },
+      ],
+    });
+    toast.present();
   }
 
   SetUserData(user: firebase.User) {


### PR DESCRIPTION
O teste piloto foi realizado na 1ª assembleia de curso presencial do CACiC (uid do evento: `NkwFYjlPGu5UgVSrrqTJ`).

Dos aproximadamente 39 scans, 2 falharam pelo erro de "QR Code inválido".
A leitura dos QR Codes foi lenta.
Houve problema com o caching do service worker, que estava exibindo uma versão anterior do aplicativo.

<table>
<thead>
  <tr>
    <th>Problema</th>
    <th>Causa</th>
    <th>Medidas tomadas</th>
  </tr>
</thead>
<tbody>
  <tr>
    <td>Aplicativo desatualizado</td>
    <td>Service worker</td>
    <td><b>No código:</b> Nada pode ser feito<br><b>Solução na hora:</b> Pedir para o usuário utilizar uma guia anônima</td>
  </tr>
  <tr>
    <td rowspan="4">Dificuldades na leitura do QR Code</td>
    <td>Tela rachada</td>
    <td><b>No código:</b> Inserção manual da presença pelo FCT App (a implementar em #34)<br><b>Solução na hora:</b> Inserção manual da presença pelo Console do Firebase</td>
  </tr>
  <tr>
    <td>Brilho baixo</td>
    <td><b>No código:</b> Nada pode ser feito<br><b>Solução na hora:</b> Pedir para o usuário aumentar o brilho da tela</td>
  </tr>
  <tr>
    <td>Reflexo da tela</td>
    <td><b>No código:</b> Aumentar error correction e version para compensar.<br><b>Solução na hora:</b> Pedir para o usuário aumentar o brilho da tela</td>
  </tr>
  <tr>
    <td>QR code com cor diferente por conta do modo noturno</td>
    <td><b>No código:</b> Renderizar QR Code como imagem ao invés de svg<br><b>Solução na hora:</b> Pedir para o usuário desativar o modo noturno</td>
  </tr>
  <tr>
    <td>QR Code de perfil inválido</td>
    <td>Documento do usuário não foi criado no Firestore<br></td>
    <td><b>No código:</b> Se ocorrer um erro no try-catch da autenticação, deslogar o usuário e mostrar um toast pedindo para fazer login novamente. Melhorar mensagens de erro nos toasts do scanner<br><b>Solução na hora:</b> Pedir para o usuário fazer logoff e login novamente</td>
  </tr>
</tbody>
</table>