### PR TITLE
Duplicate attendances and manual certificates

### DIFF
--- a/apps/admin/src/app/shared/services/workspace-certificates.service.spec.ts
+++ b/apps/admin/src/app/shared/services/workspace-certificates.service.spec.ts
@@ -385,6 +385,7 @@ describe('WorkspaceCertificatesService', () => {
             recipientData: true,
             activeState: false,
             issuedPeople: true,
+            manualPeople: false,
           },
         }),
     });
@@ -396,6 +397,7 @@ describe('WorkspaceCertificatesService', () => {
       expect.objectContaining({
         data: expect.objectContaining({
           canCopyIssuedPeople: true,
+          canCopyManualPeople: false,
         }),
       }),
     );
@@ -411,6 +413,7 @@ describe('WorkspaceCertificatesService', () => {
         recipientData: true,
         activeState: false,
         issuedPeople: true,
+        manualPeople: false,
       },
     });
   });

--- a/apps/admin/src/app/shared/services/workspace-certificates.service.ts
+++ b/apps/admin/src/app/shared/services/workspace-certificates.service.ts
@@ -428,6 +428,7 @@ export class WorkspaceCertificatesService {
         recipientData: Boolean(result.parts.recipientData),
         activeState: Boolean(result.parts.activeState),
         issuedPeople: Boolean(result.parts.issuedPeople),
+        manualPeople: Boolean(result.parts.manualPeople),
       },
     };
 
@@ -852,6 +853,7 @@ export class WorkspaceCertificatesService {
     config: CertificateConfig,
   ): Promise<CertificateConfigCloneDialogResult | null | undefined> {
     const canCopyIssuedPeople = this.permissions.hasAll([Permission.Certificate.Read, Permission.Certificate.Issue]);
+    const canCopyManualPeople = config.issuedTo === 'OTHER' && canCopyIssuedPeople;
     const dialogRef = this.dialog.open(CertificateConfigCloneDialogComponent, {
       width: '52rem',
       maxWidth: '95vw',
@@ -859,6 +861,7 @@ export class WorkspaceCertificatesService {
         config,
         defaultName: `${config.name} (cópia)`,
         canCopyIssuedPeople,
+        canCopyManualPeople,
       },
     });
 

--- a/apps/admin/src/app/shared/services/workspace-event-clone-dialog-data.spec.ts
+++ b/apps/admin/src/app/shared/services/workspace-event-clone-dialog-data.spec.ts
@@ -2,7 +2,11 @@ import { createEventCloneDialogData } from './workspace-event-clone-dialog-data'
 
 describe('createEventCloneDialogData', () => {
   it('retains every copy category while disabling only inaccessible categories', () => {
-    const data = createEventCloneDialogData('Oficina', { canCopyLecturers: false, canCopyCertificateConfig: true });
+    const data = createEventCloneDialogData('Oficina', {
+      canCopyLecturers: false,
+      canCopyCertificateConfig: true,
+      canCopyAttendances: false,
+    });
 
     expect(data.defaultName).toBe('Oficina (cópia)');
     expect(data.parts.map((part) => part.key)).toEqual([
@@ -10,10 +14,12 @@ describe('createEventCloneDialogData', () => {
       'certificateConfig',
       'subscriptionSettings',
       'attendanceSettings',
+      'attendances',
       'place',
       'visibility',
     ]);
     expect(data.parts[0]).toMatchObject({ disabled: true });
     expect(data.parts[1]).toMatchObject({ disabled: false });
+    expect(data.parts[4]).toMatchObject({ disabled: true, defaultSelected: false });
   });
 });

--- a/apps/admin/src/app/shared/services/workspace-event-clone-dialog-data.ts
+++ b/apps/admin/src/app/shared/services/workspace-event-clone-dialog-data.ts
@@ -2,7 +2,7 @@ import type { CloneAssetDialogData } from '../../workspace/dialogs/clone-asset-d
 
 export function createEventCloneDialogData(
   eventName: string,
-  permissions: { canCopyLecturers: boolean; canCopyCertificateConfig: boolean },
+  permissions: { canCopyLecturers: boolean; canCopyCertificateConfig: boolean; canCopyAttendances: boolean },
 ): CloneAssetDialogData {
   return {
     title: 'Duplicar evento',
@@ -37,6 +37,14 @@ export function createEventCloneDialogData(
         label: 'Presença',
         description: 'Copia coleta e janelas de presença, sem copiar o código de presença.',
         defaultSelected: true,
+      },
+      {
+        key: 'attendances',
+        label: 'Registros de presença',
+        description: 'Copia as pessoas presentes. O novo registro identifica quem duplicou o evento.',
+        defaultSelected: false,
+        disabled: !permissions.canCopyAttendances,
+        disabledReason: 'Exige permissão para visualizar presenças de origem e registrar presenças no novo evento.',
       },
       { key: 'place', label: 'Local', description: 'Copia coordenadas e descrição do local.', defaultSelected: true },
       {

--- a/apps/admin/src/app/shared/services/workspace-events.service.ts
+++ b/apps/admin/src/app/shared/services/workspace-events.service.ts
@@ -511,6 +511,7 @@ export class WorkspaceEventsService {
             certificateConfig: Boolean(result.parts.certificateConfig),
             subscriptionSettings: Boolean(result.parts.subscriptionSettings),
             attendanceSettings: Boolean(result.parts.attendanceSettings),
+            attendances: Boolean(result.parts.attendances),
             place: Boolean(result.parts.place),
             visibility: Boolean(result.parts.visibility),
           },
@@ -768,11 +769,19 @@ export class WorkspaceEventsService {
       Permission.CertificateConfig.Read,
       Permission.CertificateConfig.Create,
     ]);
+    const canCopyAttendances = this.permissions.hasAll([
+      Permission.EventAttendance.Read,
+      Permission.EventAttendance.Collect,
+    ]);
 
     const dialogRef = this.dialog.open(CloneAssetDialogComponent, {
       width: '52rem',
       maxWidth: '95vw',
-      data: createEventCloneDialogData(eventItem.name, { canCopyLecturers, canCopyCertificateConfig }),
+      data: createEventCloneDialogData(eventItem.name, {
+        canCopyLecturers,
+        canCopyCertificateConfig,
+        canCopyAttendances,
+      }),
     });
 
     return firstValueFrom(dialogRef.afterClosed());

--- a/apps/admin/src/app/workspace/dialogs/certificate-config-clone-dialog.component.spec.ts
+++ b/apps/admin/src/app/workspace/dialogs/certificate-config-clone-dialog.component.spec.ts
@@ -43,6 +43,7 @@ describe('CertificateConfigCloneDialogComponent', () => {
       }),
       defaultName: 'Certificate (cópia)',
       canCopyIssuedPeople: true,
+      canCopyManualPeople: true,
     });
 
     await settleAsyncWork();
@@ -77,7 +78,7 @@ describe('CertificateConfigCloneDialogComponent', () => {
     read(component).form.controls.name.setValue('  Cópia ajustada  ');
     read(component).partControls.textContent.setValue(false);
     read(component).partControls.activeState.setValue(false);
-    read(component).partControls.issuedPeople.setValue(true);
+    read(component).partControls.manualPeople.setValue(true);
 
     read(component).confirmClone();
 
@@ -90,7 +91,8 @@ describe('CertificateConfigCloneDialogComponent', () => {
         textContent: false,
         recipientData: true,
         activeState: false,
-        issuedPeople: true,
+        issuedPeople: false,
+        manualPeople: true,
       },
     });
   });
@@ -138,6 +140,7 @@ async function createFixture(
     }),
     defaultName: 'Certificate (cópia)',
     canCopyIssuedPeople: true,
+    canCopyManualPeople: true,
   },
 ): Promise<{
   component: CertificateConfigCloneDialogComponent;

--- a/apps/admin/src/app/workspace/dialogs/certificate-config-clone-dialog.component.stories.ts
+++ b/apps/admin/src/app/workspace/dialogs/certificate-config-clone-dialog.component.stories.ts
@@ -33,6 +33,7 @@ type CertificateConfigCloneDialogStoryArgs = {
   sourceScope: CertificateScope;
   targetsMode: CertificateCloneTargetsMode;
   canCopyIssuedPeople: boolean;
+  canCopyManualPeople: boolean;
 };
 
 const dialogRefMock = {
@@ -53,6 +54,7 @@ class CertificateConfigCloneDialogStoryHostComponent {
   readonly sourceScope = input<CertificateScope>('EVENT');
   readonly targetsMode = input<CertificateCloneTargetsMode>('populated');
   readonly canCopyIssuedPeople = input(true);
+  readonly canCopyManualPeople = input(true);
 
   readonly storyInjector = computed(() =>
     Injector.create({
@@ -64,6 +66,7 @@ class CertificateConfigCloneDialogStoryHostComponent {
             config: certificateConfig(this.sourceScope()),
             defaultName: this.defaultName(),
             canCopyIssuedPeople: this.canCopyIssuedPeople(),
+            canCopyManualPeople: this.canCopyManualPeople(),
           } satisfies CertificateConfigCloneDialogData,
         },
         { provide: MatDialogRef, useValue: dialogRefMock },
@@ -82,6 +85,7 @@ const meta: Meta<CertificateConfigCloneDialogStoryArgs> = {
     sourceScope: 'EVENT',
     targetsMode: 'populated',
     canCopyIssuedPeople: true,
+    canCopyManualPeople: true,
   },
   argTypes: {
     defaultName: { control: 'text' },
@@ -94,6 +98,7 @@ const meta: Meta<CertificateConfigCloneDialogStoryArgs> = {
       options: ['populated', 'empty', 'loading-error'],
     },
     canCopyIssuedPeople: { control: 'boolean' },
+    canCopyManualPeople: { control: 'boolean' },
   },
   decorators: [
     applicationConfig({
@@ -141,6 +146,7 @@ export const TargetLoadError: Story = {
 export const CannotCopyIssuedPeople: Story = {
   args: {
     canCopyIssuedPeople: false,
+    canCopyManualPeople: false,
   },
 };
 

--- a/apps/admin/src/app/workspace/dialogs/certificate-config-clone-dialog.component.ts
+++ b/apps/admin/src/app/workspace/dialogs/certificate-config-clone-dialog.component.ts
@@ -126,8 +126,7 @@ export type CertificateConfigCloneDialogResult = {
             <mat-checkbox [formControl]="partControls.issuedPeople">
               Pessoas já emitidas
             </mat-checkbox>
-          }
-          @if (data.config.issuedTo === 'OTHER') {
+          } @else {
             <mat-checkbox [formControl]="partControls.manualPeople">
               Lista de pessoas da emissão manual
             </mat-checkbox>

--- a/apps/admin/src/app/workspace/dialogs/certificate-config-clone-dialog.component.ts
+++ b/apps/admin/src/app/workspace/dialogs/certificate-config-clone-dialog.component.ts
@@ -29,6 +29,7 @@ export type CertificateConfigCloneDialogData = {
   config: CertificateConfig;
   defaultName: string;
   canCopyIssuedPeople: boolean;
+  canCopyManualPeople: boolean;
 };
 
 export type CertificateConfigCloneDialogResult = {
@@ -121,9 +122,16 @@ export type CertificateConfigCloneDialogResult = {
           <mat-checkbox [formControl]="partControls.activeState">
             Status
           </mat-checkbox>
-          <mat-checkbox [formControl]="partControls.issuedPeople">
-            Pessoas já emitidas
-          </mat-checkbox>
+          @if (data.config.issuedTo !== 'OTHER') {
+            <mat-checkbox [formControl]="partControls.issuedPeople">
+              Pessoas já emitidas
+            </mat-checkbox>
+          }
+          @if (data.config.issuedTo === 'OTHER') {
+            <mat-checkbox [formControl]="partControls.manualPeople">
+              Lista de pessoas da emissão manual
+            </mat-checkbox>
+          }
         </div>
       </section>
     </div>
@@ -239,6 +247,13 @@ export class CertificateConfigCloneDialogComponent {
       },
       { nonNullable: true },
     ),
+    manualPeople: new FormControl(
+      {
+        value: false,
+        disabled: !this.data.canCopyManualPeople,
+      },
+      { nonNullable: true },
+    ),
   };
 
   constructor() {
@@ -271,6 +286,7 @@ export class CertificateConfigCloneDialogComponent {
         recipientData: this.partControls.recipientData.value,
         activeState: this.partControls.activeState.value,
         issuedPeople: this.partControls.issuedPeople.value,
+        manualPeople: this.partControls.manualPeople.value,
       },
     });
   }

--- a/apps/admin/src/app/workspace/dialogs/clone-asset-dialog.component.ts
+++ b/apps/admin/src/app/workspace/dialogs/clone-asset-dialog.component.ts
@@ -12,6 +12,7 @@ export type CloneAssetPartKey =
   | 'certificateConfig'
   | 'subscriptionSettings'
   | 'attendanceSettings'
+  | 'attendances'
   | 'place'
   | 'visibility'
   | 'paymentSettings';

--- a/apps/admin/src/app/workspace/dialogs/workspace-attendance-info-dialog.component.stories.ts
+++ b/apps/admin/src/app/workspace/dialogs/workspace-attendance-info-dialog.component.stories.ts
@@ -78,7 +78,10 @@ const meta: Meta<AttendanceInfoStoryArgs> = {
     personName: { control: 'text' },
     eventName: { control: 'text' },
     category: { control: 'select', options: ['REGULAR', 'NON_PAYING', 'NON_SUBSCRIBED', 'UNKNOWN'] },
-    createdByMethod: { control: 'select', options: ['SCANNER', 'MANUAL_INPUT', 'CSV_IMPORT', 'ONLINE_CODE', 'UNKNOWN'] },
+    createdByMethod: {
+      control: 'select',
+      options: ['SCANNER', 'MANUAL_INPUT', 'CSV_IMPORT', 'EVENT_DUPLICATION', 'ONLINE_CODE', 'UNKNOWN'],
+    },
     hasLocation: { control: 'boolean' },
     collectedAccuracyMeters: { control: { type: 'range', min: 0, max: 80, step: 1 } },
   },

--- a/apps/admin/src/app/workspace/dialogs/workspace-attendance-info-dialog.component.ts
+++ b/apps/admin/src/app/workspace/dialogs/workspace-attendance-info-dialog.component.ts
@@ -212,6 +212,7 @@ export class WorkspaceAttendanceInfoDialogComponent {
   private getMethodLabel(method: string): string {
     const labels: Record<string, string> = {
       CSV_IMPORT: 'Importação CSV',
+      EVENT_DUPLICATION: 'Duplicação de evento',
       MANUAL_INPUT: 'Manual',
       ONLINE_CODE: 'Online',
       SCANNER: 'Scanner',

--- a/apps/admin/src/app/workspace/dialogs/workspace-attendance-scanner-dialog.component.ts
+++ b/apps/admin/src/app/workspace/dialogs/workspace-attendance-scanner-dialog.component.ts
@@ -271,6 +271,8 @@ export class WorkspaceAttendanceScannerDialogComponent implements OnInit {
     switch (method) {
       case 'CSV_IMPORT':
         return 'CSV';
+      case 'EVENT_DUPLICATION':
+        return 'duplicação de evento';
       case 'MANUAL_INPUT':
         return 'manual';
       case 'SCANNER':

--- a/apps/backend/prisma/migrations/20260718120000_event_attendance_duplication/migration.sql
+++ b/apps/backend/prisma/migrations/20260718120000_event_attendance_duplication/migration.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "AttendanceCreationMethod" ADD VALUE 'EVENT_DUPLICATION';

--- a/apps/backend/prisma/schema/attendance.prisma
+++ b/apps/backend/prisma/schema/attendance.prisma
@@ -90,6 +90,7 @@ model OfflineEventAttendanceSubmission {
 
 enum AttendanceCreationMethod {
   CSV_IMPORT
+  EVENT_DUPLICATION
   MANUAL_INPUT
   SCANNER
   ONLINE_CODE

--- a/apps/backend/src/app/certificate/certificate-configs.service.spec.ts
+++ b/apps/backend/src/app/certificate/certificate-configs.service.spec.ts
@@ -590,7 +590,7 @@ describe('CertificateConfigsService', () => {
           recipientData: true,
           activeState: true,
         },
-      }),
+      }, { actor: { sub: 'duplicating-user' } as never }),
     ).resolves.toEqual(
       expect.objectContaining({
         id: 'config-copy',
@@ -613,6 +613,8 @@ describe('CertificateConfigsService', () => {
           certificateFields: {
             cidade: 'Presidente Prudente',
           },
+          createdById: 'duplicating-user',
+          updatedById: 'duplicating-user',
         }),
       }),
     );

--- a/apps/backend/src/app/certificate/certificate-configs.service.ts
+++ b/apps/backend/src/app/certificate/certificate-configs.service.ts
@@ -15,6 +15,7 @@ import { BadRequestException, ConflictException, Injectable, NotFoundException }
 import { AuditLogEntityType, AuditLogOperation, Prisma } from '@prisma/client';
 import { AuditLogService } from '../audit-log/audit-log.service';
 import { AuditPrismaClient } from '../audit-log/audit-log.types';
+import { AuthenticatedUser } from '../auth/interfaces/authenticated-user.interface';
 import { PrismaService } from '../prisma/prisma.service';
 import { TypesenseSearchService } from '../search/typesense-search.service';
 import {
@@ -33,6 +34,10 @@ import { CertificateValidationService } from './certificate-validation.service';
 const LECTURER_EVENT_CATEGORY_FIELD = '__lecturerEventCategory';
 type LecturerEventCategory = 'PALESTRA' | 'MINICURSO' | 'OTHER';
 type CertificateFolderWriteClient = AuditPrismaClient;
+type CertificateConfigCloneOptions = {
+  client?: AuditPrismaClient;
+  actor?: AuthenticatedUser;
+};
 
 @Injectable()
 export class CertificateConfigsService {
@@ -574,9 +579,18 @@ export class CertificateConfigsService {
     return mapCertificateConfig(updatedConfig);
   }
 
-  async cloneConfig(configId: string, input: CertificateConfigCloneInput | null): Promise<CertificateConfig> {
+  async cloneConfig(
+    configId: string,
+    input: CertificateConfigCloneInput | null,
+    options: CertificateConfigCloneOptions = {},
+  ): Promise<CertificateConfig> {
+    if (!options.client || options.client === this.prisma) {
+      return this.prisma.$transaction((tx) => this.cloneConfig(configId, input, { ...options, client: tx }));
+    }
+
+    const client = options.client;
     const normalizedConfigId = this.validation.normalizeRequiredId('configId', configId);
-    const source = await this.prisma.certificateConfig.findFirst({
+    const source = await client.certificateConfig.findFirst({
       where: {
         id: normalizedConfigId,
         deletedAt: null,
@@ -641,7 +655,7 @@ export class CertificateConfigsService {
       await this.targetsService.assertIssuableTarget(scope, targetId);
     }
     const parts = input?.parts;
-    const shouldCopyRecipientData = Boolean(parts?.recipientData || parts?.issuedPeople);
+    const shouldCopyRecipientData = Boolean(parts?.recipientData || parts?.issuedPeople || parts?.manualPeople);
     const defaultIssuedTo = scope === CertificateScope.OTHER ? CertificateIssuedTo.OTHER : CertificateIssuedTo.ATTENDEE;
     const issuedTo =
       scope === CertificateScope.OTHER
@@ -655,14 +669,13 @@ export class CertificateConfigsService {
       : this.resolveCertificateTypeLabel(issuedTo, certificateFields, undefined);
     const name =
       input?.name === undefined || input.name === null
-        ? await this.buildUniqueCloneName(scope, targetId, source.name)
+        ? await this.buildUniqueCloneName(scope, targetId, source.name, client)
         : this.validation.normalizeRequiredName(input.name);
 
-    await this.ensureNoDuplicateName(scope, targetId, name);
+    await this.ensureNoDuplicateName(scope, targetId, name, undefined, client);
 
-    const createdConfig = await this.prisma.$transaction(async (tx) => {
-      const config = await tx.certificateConfig.create({
-        data: {
+    const createdConfig = await client.certificateConfig.create({
+      data: {
         name,
         scope,
         majorEventId,
@@ -682,12 +695,19 @@ export class CertificateConfigsService {
         issuedTo,
         certificateTypeLabel,
         certificateFields: this.toJsonCreateValue(certificateFields),
-        },
-        select: CERTIFICATE_CONFIG_SELECT,
-      });
-      await this.recordConfigAudit(null, config, AuditLogOperation.CREATE, tx, 'Configuração de certificado clonada.');
-      return config;
+        createdById: options.actor?.sub,
+        updatedById: options.actor?.sub,
+      },
+      select: CERTIFICATE_CONFIG_SELECT,
     });
+    await this.recordConfigAudit(
+      null,
+      createdConfig,
+      AuditLogOperation.CREATE,
+      client,
+      'Configuração de certificado clonada.',
+      options.actor,
+    );
 
     return mapCertificateConfig(createdConfig);
   }
@@ -722,8 +742,9 @@ export class CertificateConfigsService {
     before: CertificateConfigRecord | null,
     after: CertificateConfigRecord,
     operation: AuditLogOperation,
-    prisma: Prisma.TransactionClient,
+    prisma: AuditPrismaClient,
     summary?: string,
+    actor?: AuthenticatedUser,
   ): Promise<void> {
     await this.auditLog.record(
       {
@@ -745,6 +766,7 @@ export class CertificateConfigsService {
           eventGroupId: after.eventGroupId,
           majorEventId: after.majorEventId,
         },
+        actor,
       },
       prisma as unknown as AuditPrismaClient,
     );
@@ -919,8 +941,9 @@ export class CertificateConfigsService {
     targetId: string,
     name: string,
     excludeId?: string,
+    client: Pick<AuditPrismaClient, 'certificateConfig'> = this.prisma,
   ): Promise<void> {
-    const duplicate = await this.prisma.certificateConfig.findFirst({
+    const duplicate = await client.certificateConfig.findFirst({
       where: {
         deletedAt: null,
         name: {
@@ -940,12 +963,17 @@ export class CertificateConfigsService {
     }
   }
 
-  private async buildUniqueCloneName(scope: CertificateScope, targetId: string, sourceName: string): Promise<string> {
+  private async buildUniqueCloneName(
+    scope: CertificateScope,
+    targetId: string,
+    sourceName: string,
+    client: Pick<AuditPrismaClient, 'certificateConfig'> = this.prisma,
+  ): Promise<string> {
     const baseName = `${sourceName} (cópia)`;
     let name = baseName;
     let copyIndex = 2;
 
-    while (await this.hasDuplicateName(scope, targetId, name)) {
+    while (await this.hasDuplicateName(scope, targetId, name, client)) {
       name = `${baseName} ${copyIndex}`;
       copyIndex += 1;
     }
@@ -953,8 +981,13 @@ export class CertificateConfigsService {
     return name;
   }
 
-  private async hasDuplicateName(scope: CertificateScope, targetId: string, name: string): Promise<boolean> {
-    const duplicate = await this.prisma.certificateConfig.findFirst({
+  private async hasDuplicateName(
+    scope: CertificateScope,
+    targetId: string,
+    name: string,
+    client: Pick<AuditPrismaClient, 'certificateConfig'> = this.prisma,
+  ): Promise<boolean> {
+    const duplicate = await client.certificateConfig.findFirst({
       where: {
         deletedAt: null,
         name: {

--- a/apps/backend/src/app/certificate/certificate-issuing.service.spec.ts
+++ b/apps/backend/src/app/certificate/certificate-issuing.service.spec.ts
@@ -1,5 +1,5 @@
 import { CertificateIssuedTo, CertificateScope, EventType } from '@cacic-fct/shared-data-types';
-import { BadRequestException } from '@nestjs/common';
+import { BadRequestException, Logger } from '@nestjs/common';
 import { addMinutes } from 'date-fns';
 import { buildCertificateRenderedData, buildMinicursoLines, formatCargaHoraria } from './certificate-rendered-data';
 import { CertificateIssuingService } from './certificate-issuing.service';
@@ -412,6 +412,17 @@ describe('CertificateIssuingService', () => {
     await service.issueForExistingConfigRecipients('source-config', 'target-config', 'admin-user');
 
     expect(notificationJobs.enqueue).toHaveBeenCalledWith(mappedCertificateRecord);
+  });
+
+  it('does not reject a completed clone when queuing a copied certificate notification fails', async () => {
+    const notificationJobs = { enqueue: jest.fn().mockRejectedValue(new Error('Redis unavailable')) };
+    const logError = jest.spyOn(Logger.prototype, 'error').mockImplementation();
+    const service = new CertificateIssuingService({} as never, {} as never, {} as never, undefined, undefined, notificationJobs as never);
+
+    await expect(service.notifyCopiedCertificates([mappedCertificateRecord])).resolves.toBeUndefined();
+
+    expect(notificationJobs.enqueue).toHaveBeenCalledWith(mappedCertificateRecord);
+    expect(logError).toHaveBeenCalledWith('Could not enqueue a copied certificate notification.', expect.any(Error));
   });
 
   it('propagates unexpected failures before writing cloned recipient certificates', async () => {

--- a/apps/backend/src/app/certificate/certificate-issuing.service.spec.ts
+++ b/apps/backend/src/app/certificate/certificate-issuing.service.spec.ts
@@ -285,6 +285,45 @@ describe('CertificateIssuingService', () => {
     expect(upsertSpy).toHaveBeenCalledWith(config, recipient, 'admin-user');
   });
 
+  it('copies manual recipients through the caller transaction with the duplicator as issuer', async () => {
+    const sourceConfig = { ...mappedCertificateRecord.config, id: 'source-config', issuedTo: CertificateIssuedTo.OTHER };
+    const targetConfig = { ...mappedCertificateRecord.config, id: 'target-config', issuedTo: CertificateIssuedTo.OTHER };
+    const transaction = {
+      certificateConfig: {
+        findFirst: jest.fn().mockResolvedValueOnce(sourceConfig).mockResolvedValueOnce(targetConfig),
+      },
+      certificate: {
+        findMany: jest.fn().mockResolvedValue([{ personId: 'person-1' }]),
+      },
+      user: {
+        findUnique: jest.fn().mockResolvedValue({ name: 'Duplicator', email: 'duplicator@example.com' }),
+      },
+    };
+    const service = new CertificateIssuingService(
+      {} as never,
+      { normalizeRequiredId: jest.fn((_field: string, value: string) => value) } as never,
+      {} as never,
+    );
+    const recipient = { person: mappedCertificateRecord.person, events: [] };
+    jest.spyOn(service as never, 'resolveRecipientForConfig').mockResolvedValue(recipient);
+    const copiedCertificate = { ...mappedCertificateRecord, config: targetConfig };
+    const upsert = jest.spyOn(service as never, 'upsertCertificateForRecipientResult').mockResolvedValue({
+      certificate: copiedCertificate,
+      shouldNotify: true,
+    });
+
+    await expect(service.copyManualRecipients('source-config', 'target-config', 'duplicating-user', transaction as never)).resolves.toEqual([
+      copiedCertificate,
+    ]);
+
+    expect(upsert).toHaveBeenCalledWith(
+      targetConfig,
+      recipient,
+      'duplicating-user',
+      expect.objectContaining({ prisma: transaction, notify: false }),
+    );
+  });
+
   it('copies existing issued recipients in batches without failing the whole copy on one ineligible person', async () => {
     const prisma = {
       $transaction: jest.fn(async (callback: (tx: unknown) => Promise<unknown>) => callback({})),

--- a/apps/backend/src/app/certificate/certificate-issuing.service.ts
+++ b/apps/backend/src/app/certificate/certificate-issuing.service.ts
@@ -7,6 +7,7 @@ import { NovuNotificationsService } from '../notifications/novu-notifications.se
 import { PrismaService } from '../prisma/prisma.service';
 import {
   CERTIFICATE_SELECT,
+  CERTIFICATE_CONFIG_SELECT,
   CertificateRecord,
   CertificateConfigRecord,
   buildConfigTargetWhere,
@@ -202,6 +203,78 @@ export class CertificateIssuingService {
     );
 
     return issuedCertificates.map((issued) => mapCertificate(issued.certificate));
+  }
+
+  async copyManualRecipients(
+    sourceConfigId: string,
+    targetConfigId: string,
+    issuedById: string | undefined,
+    client: CertificateWriteClient,
+  ): Promise<CertificateRecord[]> {
+    const normalizedSourceConfigId = this.validation.normalizeRequiredId('sourceConfigId', sourceConfigId);
+    const normalizedTargetConfigId = this.validation.normalizeRequiredId('targetConfigId', targetConfigId);
+    const [sourceConfig, targetConfig] = await Promise.all(
+      [normalizedSourceConfigId, normalizedTargetConfigId].map((id) =>
+        client.certificateConfig.findFirst({
+          where: { id, deletedAt: null },
+          select: CERTIFICATE_CONFIG_SELECT,
+        }),
+      ),
+    );
+
+    if (!sourceConfig || !targetConfig) {
+      throw new NotFoundException('Certificate config was not found while copying manual recipients.');
+    }
+    if (sourceConfig.issuedTo !== CertificateIssuedTo.OTHER || targetConfig.issuedTo !== CertificateIssuedTo.OTHER) {
+      throw new BadRequestException('Manual recipients can only be copied between manual certificate configurations.');
+    }
+
+    const sourceCertificates = await client.certificate.findMany({
+      where: {
+        configId: normalizedSourceConfigId,
+        deletedAt: null,
+        person: { deletedAt: null },
+      },
+      select: { personId: true },
+      orderBy: { issuedAt: 'asc' },
+    });
+    const auditActor = await this.audit.resolveActor(issuedById, client);
+    const issuedCertificates: CertificateRecord[] = [];
+
+    for (let index = 0; index < sourceCertificates.length; index += CertificateIssuingService.CERTIFICATE_ISSUING_BATCH_SIZE) {
+      const batch = sourceCertificates.slice(index, index + CertificateIssuingService.CERTIFICATE_ISSUING_BATCH_SIZE);
+      const results = await Promise.allSettled(
+        batch.map(async ({ personId }) => {
+          const recipient = await this.resolveRecipientForConfig(targetConfig, normalizedTargetConfigId, personId);
+          return this.upsertCertificateForRecipientResult(targetConfig, recipient, issuedById, {
+            auditActor,
+            notify: false,
+            prisma: client,
+          });
+        }),
+      );
+      const unexpectedError = results.find(
+        (result): result is PromiseRejectedResult =>
+          result.status === 'rejected' && !this.isExpectedRecipientSkipError(result.reason),
+      );
+      if (unexpectedError) {
+        throw unexpectedError.reason;
+      }
+      issuedCertificates.push(
+        ...results
+          .filter(
+            (result): result is PromiseFulfilledResult<{ certificate: CertificateRecord; shouldNotify: boolean }> =>
+              result.status === 'fulfilled' && result.value.shouldNotify,
+          )
+          .map((result) => result.value.certificate),
+      );
+    }
+
+    return issuedCertificates;
+  }
+
+  async notifyCopiedCertificates(certificates: CertificateRecord[]): Promise<void> {
+    await Promise.all(certificates.map((certificate) => this.notifyCertificateAvailable(certificate)));
   }
 
   private isExpectedRecipientSkipError(error: unknown): boolean {

--- a/apps/backend/src/app/certificate/certificate-issuing.service.ts
+++ b/apps/backend/src/app/certificate/certificate-issuing.service.ts
@@ -1,5 +1,5 @@
 import { Certificate, CertificateIssuedTo, CertificateReissueResult, CertificateScope, DeletionResult } from '@cacic-fct/shared-data-types';
-import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { AuditLogOperation, Prisma } from '@prisma/client';
 import { AuditLogService } from '../audit-log/audit-log.service';
 import { AuditActor, AuditPrismaClient } from '../audit-log/audit-log.types';
@@ -28,6 +28,7 @@ type CertificateReissueClient = AuditPrismaClient;
 @Injectable()
 export class CertificateIssuingService {
   private static readonly CERTIFICATE_ISSUING_BATCH_SIZE = 10;
+  private readonly logger = new Logger(CertificateIssuingService.name);
   private readonly audit: CertificateIssuanceAudit;
   private readonly refresh: CertificateIssuanceRefresh;
   private readonly recipients: CertificateIssuanceRecipients;
@@ -274,7 +275,12 @@ export class CertificateIssuingService {
   }
 
   async notifyCopiedCertificates(certificates: CertificateRecord[]): Promise<void> {
-    await Promise.all(certificates.map((certificate) => this.notifyCertificateAvailable(certificate)));
+    const results = await Promise.allSettled(certificates.map((certificate) => this.notifyCertificateAvailable(certificate)));
+    for (const result of results) {
+      if (result.status === 'rejected') {
+        this.logger.error('Could not enqueue a copied certificate notification.', result.reason);
+      }
+    }
   }
 
   private isExpectedRecipientSkipError(error: unknown): boolean {

--- a/apps/backend/src/app/certificate/certificates.resolver.spec.ts
+++ b/apps/backend/src/app/certificate/certificates.resolver.spec.ts
@@ -1,4 +1,4 @@
-import { CertificateScope } from '@cacic-fct/shared-data-types';
+import { CertificateIssuedTo, CertificateScope } from '@cacic-fct/shared-data-types';
 import { Permission } from '@cacic-fct/shared-permissions';
 import { TURNSTILE_ACTIONS } from '@cacic-fct/shared-utils';
 import { BadRequestException, ForbiddenException } from '@nestjs/common';
@@ -384,7 +384,56 @@ describe('CertificatesResolver authorization', () => {
         targetId: 'folder-1',
       },
     );
-    expect(configsService.cloneConfig).toHaveBeenCalledWith('config-1', null);
+    expect(configsService.cloneConfig).toHaveBeenCalledWith(
+      'config-1',
+      null,
+      expect.objectContaining({ actor: user, client: expect.anything() }),
+    );
+  });
+
+  it('copies a manual people list atomically and attributes it to the duplicator', async () => {
+    const { authorizationPolicy, configsService, issuingService, prisma, resolver } = createResolver();
+    const user = { sub: 'user-1' };
+    configsService.getConfigById.mockResolvedValue({
+      id: 'config-1',
+      scope: CertificateScope.OTHER,
+      folderId: 'folder-1',
+      issuedTo: CertificateIssuedTo.OTHER,
+    });
+    configsService.cloneConfig.mockResolvedValue({
+      id: 'config-copy',
+      scope: CertificateScope.OTHER,
+      folderId: 'folder-1',
+    });
+    const copiedCertificate = { id: 'certificate-copy' };
+    issuingService.copyManualRecipients.mockResolvedValue([copiedCertificate]);
+
+    await resolver.cloneCertificateConfig(
+      'config-1',
+      { parts: { manualPeople: true } },
+      { req: { user } } as never,
+    );
+
+    expect(authorizationPolicy.assertPermissions).toHaveBeenNthCalledWith(
+      3,
+      user,
+      [Permission.Certificate.Read],
+      { scope: CertificateScope.OTHER, targetId: 'folder-1' },
+    );
+    expect(authorizationPolicy.assertPermissions).toHaveBeenNthCalledWith(
+      4,
+      user,
+      [Permission.Certificate.Issue],
+      { scope: CertificateScope.OTHER, targetId: 'folder-1' },
+    );
+    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+    expect(configsService.cloneConfig).toHaveBeenCalledWith(
+      'config-1',
+      { parts: { manualPeople: true } },
+      expect.objectContaining({ actor: user, client: prisma }),
+    );
+    expect(issuingService.copyManualRecipients).toHaveBeenCalledWith('config-1', 'config-copy', 'user-1', prisma);
+    expect(issuingService.notifyCopiedCertificates).toHaveBeenCalledWith([copiedCertificate]);
   });
 
   it('deletes certificate configs after frozen delete validation', async () => {
@@ -731,6 +780,8 @@ function createResolver() {
     listCertificatesByTarget: jest.fn(),
     issueForPerson: jest.fn(),
     issueForExistingConfigRecipients: jest.fn(),
+    copyManualRecipients: jest.fn(),
+    notifyCopiedCertificates: jest.fn(),
     issueMissedCertificates: jest.fn(),
     reissueAllCertificates: jest.fn(),
     reissueCertificatesForFolder: jest.fn(),

--- a/apps/backend/src/app/certificate/certificates.resolver.ts
+++ b/apps/backend/src/app/certificate/certificates.resolver.ts
@@ -356,7 +356,14 @@ export class CertificatesResolver {
       scope,
       targetId,
     });
-    if (input?.parts?.issuedPeople) {
+    const shouldCopyManualPeople = Boolean(input?.parts?.manualPeople);
+    if (shouldCopyManualPeople && input?.parts?.issuedPeople) {
+      throw new BadRequestException('Choose either issued people or the manual people list when cloning a certificate config.');
+    }
+    if (shouldCopyManualPeople && source.issuedTo !== 'OTHER') {
+      throw new BadRequestException('Only manual certificate configurations have a manual people list to copy.');
+    }
+    if (input?.parts?.issuedPeople || shouldCopyManualPeople) {
       await this.authorizationPolicy.assertPermissions(user, [Permission.Certificate.Read], {
         scope: source.scope,
         targetId: sourceTargetId,
@@ -367,7 +374,16 @@ export class CertificatesResolver {
       });
     }
 
-    const created = await this.configsService.cloneConfig(id, input);
+    const { created, copiedManualCertificates } = await this.prisma.$transaction(async (tx) => {
+      const createdConfig = await this.configsService.cloneConfig(id, input, { client: tx, actor: user });
+      const copiedManualCertificates = shouldCopyManualPeople
+        ? await this.issuingService.copyManualRecipients(id, createdConfig.id, this.getIssuedById(context), tx)
+        : [];
+      return { created: createdConfig, copiedManualCertificates };
+    });
+    if (copiedManualCertificates.length > 0) {
+      await this.issuingService.notifyCopiedCertificates(copiedManualCertificates);
+    }
     if (input?.parts?.issuedPeople) {
       await this.issuingService.issueForExistingConfigRecipients(id, created.id, this.getIssuedById(context));
     }

--- a/apps/backend/src/app/events/resolver.spec.ts
+++ b/apps/backend/src/app/events/resolver.spec.ts
@@ -343,6 +343,12 @@ describe('EventsResolver', () => {
       updatedAt: new Date('2026-06-01T12:00:00.000Z'),
       updatedById: 'creator',
       lecturers: [{ personId: 'person-1' }],
+      attendances: [
+        {
+          personId: 'person-2',
+          attendedAt: new Date('2026-07-01T12:30:00.000Z'),
+        },
+      ],
       certificateConfigs: [
         {
           name: 'Participante',
@@ -374,6 +380,9 @@ describe('EventsResolver', () => {
       certificateConfig: {
         create: jest.fn(),
       },
+      eventAttendance: {
+        createMany: jest.fn().mockResolvedValue({ count: 1 }),
+      },
     };
     const prisma = {
       event: {
@@ -400,6 +409,9 @@ describe('EventsResolver', () => {
     const auditLog = {
       record: jest.fn(),
     };
+    const attendanceCategories = {
+      refreshForEventPersons: jest.fn(),
+    };
     const resolver = new EventsResolver(
       prisma as never,
       typesenseSearch as never,
@@ -407,6 +419,7 @@ describe('EventsResolver', () => {
       frozenResources as never,
       authorizationPolicy as never,
       auditLog as never,
+      attendanceCategories as never,
     );
 
     await expect(
@@ -419,6 +432,7 @@ describe('EventsResolver', () => {
             certificateConfig: true,
             subscriptionSettings: true,
             attendanceSettings: true,
+            attendances: true,
             place: true,
             visibility: true,
           },
@@ -461,6 +475,31 @@ describe('EventsResolver', () => {
         certificateTemplateId: 'template-1',
       }),
     });
+    expect(tx.eventAttendance.createMany).toHaveBeenCalledWith({
+      data: [
+        {
+          personId: 'person-2',
+          eventId: 'event-clone',
+          attendedAt: new Date('2026-07-01T12:30:00.000Z'),
+          createdById: 'admin-1',
+          committedById: 'admin-1',
+          createdByMethod: 'EVENT_DUPLICATION',
+        },
+      ],
+    });
+    expect(attendanceCategories.refreshForEventPersons).toHaveBeenCalledWith(['event-clone'], ['person-2'], tx);
+    expect(prisma.event.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        select: expect.objectContaining({
+          attendances: {
+            select: {
+              personId: true,
+              attendedAt: true,
+            },
+          },
+        }),
+      }),
+    );
     expect(authorizationPolicy.assertPermissions).toHaveBeenCalledWith(
       { sub: 'admin-1' },
       [Permission.EventLecturer.Read],
@@ -505,11 +544,33 @@ describe('EventsResolver', () => {
         eventGroupId: 'group-1',
       },
     );
-    expect(authorizationPolicy.assertPermissions).toHaveBeenCalledTimes(6);
+    expect(authorizationPolicy.assertPermissions).toHaveBeenCalledWith(
+      { sub: 'admin-1' },
+      [Permission.EventAttendance.Read],
+      {
+        eventId: 'event-source',
+      },
+    );
+    expect(authorizationPolicy.assertPermissions).toHaveBeenCalledWith(
+      { sub: 'admin-1' },
+      [Permission.EventAttendance.Collect],
+      {
+        majorEventId: 'major-1',
+        eventGroupId: 'group-1',
+      },
+    );
+    expect(authorizationPolicy.assertPermissions).toHaveBeenCalledTimes(8);
     expect(auditLog.record).toHaveBeenCalledWith(
       expect.objectContaining({
         entityId: 'event-clone',
-        summary: 'Evento criado como cópia de Oficina de Git.',
+        summary: 'Evento criado como cópia de Oficina de Git, com 1 registro de presença copiado.',
+        metadata: {
+          copiedAttendances: {
+            sourceEventId: 'event-source',
+            count: 1,
+            creationMethod: 'EVENT_DUPLICATION',
+          },
+        },
       }),
       tx,
     );

--- a/apps/backend/src/app/events/resolver.ts
+++ b/apps/backend/src/app/events/resolver.ts
@@ -6,6 +6,7 @@ import { addHours, subHours } from 'date-fns';
 import {
   AuditLogEntityType,
   AuditLogOperation,
+  AttendanceCreationMethod,
   CertificateScope,
   Prisma,
   PublicationState as PrismaPublicationState,
@@ -23,6 +24,7 @@ import { FrozenResourceService } from '../common/frozen-resource.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { TypesenseSearchService } from '../search/typesense-search.service';
 import { CurrentUserOnlineAttendanceRealtimeService } from '../current-user/events/attendance-realtime.service';
+import { AttendanceCategoryService } from './attendance-category.service';
 import { resolvePublicationActorId } from '../publishing/publishing-auth';
 import { omitPublicationAuditFields } from '../publishing/publishing-audit';
 
@@ -200,6 +202,11 @@ const EVENT_CLONE_SOURCE_SELECT = {
   },
 } satisfies Prisma.EventSelect;
 
+const EVENT_CLONE_ATTENDANCE_SELECT = {
+  personId: true,
+  attendedAt: true,
+} satisfies Prisma.EventAttendanceSelect;
+
 const DEFAULT_DRAFT_EVENT_NAME = 'Evento sem título';
 const DEFAULT_EVENT_DURATION_HOURS = 1;
 
@@ -214,6 +221,9 @@ export class EventsResolver {
     private readonly auditLog: AuditLogService = {
       record: async () => undefined,
     } as unknown as AuditLogService,
+    private readonly attendanceCategories: AttendanceCategoryService = {
+      refreshForEventPersons: async () => undefined,
+    } as unknown as AttendanceCategoryService,
   ) {}
 
   @Query(() => [Event], { name: 'events' })
@@ -515,19 +525,29 @@ export class EventsResolver {
     @Args('input', { type: () => EventCloneInput, nullable: true }) input: EventCloneInput | null,
     @Context() context: GraphqlContext,
   ) {
+    const parts = input?.parts;
+    const shouldCopyAttendances = Boolean(parts?.attendances);
     const source = await this.prisma.event.findFirst({
       where: {
         id,
         deletedAt: null,
       },
-      select: EVENT_CLONE_SOURCE_SELECT,
+      select: {
+        ...EVENT_CLONE_SOURCE_SELECT,
+        ...(shouldCopyAttendances
+          ? {
+              attendances: {
+                select: EVENT_CLONE_ATTENDANCE_SELECT,
+              },
+            }
+          : {}),
+      },
     });
 
     if (!source) {
       throw new NotFoundException(`Event ${id} was not found.`);
     }
 
-    const parts = input?.parts;
     const shouldCopyLecturers = Boolean(parts?.lecturers);
     const shouldCopyCertificateConfig = Boolean(parts?.certificateConfig);
     if (shouldCopyLecturers) {
@@ -537,6 +557,11 @@ export class EventsResolver {
     }
     if (shouldCopyCertificateConfig) {
       await this.authorizationPolicy.assertPermissions(this.getUser(context), [Permission.CertificateConfig.Read], {
+        eventId: source.id,
+      });
+    }
+    if (shouldCopyAttendances) {
+      await this.authorizationPolicy.assertPermissions(this.getUser(context), [Permission.EventAttendance.Read], {
         eventId: source.id,
       });
     }
@@ -615,6 +640,13 @@ export class EventsResolver {
         cloneTargetContext,
       );
     }
+    if (shouldCopyAttendances) {
+      await this.authorizationPolicy.assertPermissions(
+        this.getUser(context),
+        [Permission.EventAttendance.Collect],
+        cloneTargetContext,
+      );
+    }
     await this.frozenResources.assertEventCreateTargetsMutable(cloneInput, this.getUser(context));
     const normalizedInput = this.applyEventCreateDefaults(await this.normalizeEventCertificateInput(cloneInput));
     const eventInput = { ...normalizedInput };
@@ -649,6 +681,13 @@ export class EventsResolver {
         await this.cloneCertificateConfigsForEvent(tx, source.certificateConfigs, createdEvent.id);
       }
 
+      const copiedAttendanceCount = await this.cloneAttendancesForEvent(
+        tx,
+        source.attendances ?? [],
+        createdEvent.id,
+        actorId,
+      );
+
       await this.disableGroupPerEventModeForMajorEvent(createdEvent, tx);
       await this.auditLog.record(
         {
@@ -664,7 +703,16 @@ export class EventsResolver {
             majorEventId: createdEvent.majorEventId,
             eventGroupId: createdEvent.eventGroupId,
           },
-          summary: `Evento criado como cópia de ${source.name}.`,
+          summary: this.buildCloneAuditSummary(source.name, shouldCopyAttendances ? copiedAttendanceCount : undefined),
+          metadata: shouldCopyAttendances
+            ? {
+                copiedAttendances: {
+                  sourceEventId: source.id,
+                  count: copiedAttendanceCount,
+                  creationMethod: AttendanceCreationMethod.EVENT_DUPLICATION,
+                },
+              }
+            : undefined,
         },
         tx,
       );
@@ -990,9 +1038,43 @@ export class EventsResolver {
     }
   }
 
+  private async cloneAttendancesForEvent(
+    tx: Prisma.TransactionClient,
+    attendances: Array<{ personId: string; attendedAt: Date }>,
+    eventId: string,
+    actorId: string | undefined,
+  ): Promise<number> {
+    if (attendances.length === 0) {
+      return 0;
+    }
+
+    const personIds = attendances.map((attendance) => attendance.personId);
+    const result = await tx.eventAttendance.createMany({
+      data: attendances.map((attendance) => ({
+        personId: attendance.personId,
+        eventId,
+        attendedAt: attendance.attendedAt,
+        createdById: actorId,
+        committedById: actorId,
+        createdByMethod: AttendanceCreationMethod.EVENT_DUPLICATION,
+      })),
+    });
+    await this.attendanceCategories.refreshForEventPersons([eventId], personIds, tx);
+    return result.count;
+  }
+
   private buildCloneName(inputName: string | null | undefined, sourceName: string): string {
     const name = inputName?.trim();
     return name || `${sourceName} (cópia)`;
+  }
+
+  private buildCloneAuditSummary(sourceName: string, copiedAttendanceCount: number | undefined): string {
+    if (copiedAttendanceCount === undefined) {
+      return `Evento criado como cópia de ${sourceName}.`;
+    }
+
+    const attendanceLabel = copiedAttendanceCount === 1 ? 'registro de presença copiado' : 'registros de presença copiados';
+    return `Evento criado como cópia de ${sourceName}, com ${copiedAttendanceCount} ${attendanceLabel}.`;
   }
 
   private getUser(context: GraphqlContext): AuthenticatedUser | undefined {

--- a/apps/public/src/app/attendance/collection/attendance-collection-api.service.ts
+++ b/apps/public/src/app/attendance/collection/attendance-collection-api.service.ts
@@ -3,7 +3,13 @@ import { Injectable, NgZone, inject } from '@angular/core';
 import type { PublicEvent } from '@cacic-fct/event-manager-public-contracts';
 import { Observable, map } from 'rxjs';
 
-export type AttendanceCreationMethod = 'CSV_IMPORT' | 'MANUAL_INPUT' | 'SCANNER' | 'ONLINE_CODE' | 'UNKNOWN';
+export type AttendanceCreationMethod =
+  | 'CSV_IMPORT'
+  | 'EVENT_DUPLICATION'
+  | 'MANUAL_INPUT'
+  | 'SCANNER'
+  | 'ONLINE_CODE'
+  | 'UNKNOWN';
 export type AttendanceCategory = 'NON_PAYING' | 'NON_SUBSCRIBED' | 'REGULAR' | 'UNKNOWN';
 
 export interface AttendanceCollectionEvent {

--- a/apps/public/src/app/attendance/collection/attendance-scanner.ts
+++ b/apps/public/src/app/attendance/collection/attendance-scanner.ts
@@ -231,6 +231,8 @@ export class AttendanceScanner implements OnInit {
     switch (method) {
       case 'CSV_IMPORT':
         return 'CSV';
+      case 'EVENT_DUPLICATION':
+        return 'duplicação de evento';
       case 'MANUAL_INPUT':
         return 'manual';
       case 'SCANNER':

--- a/libs/event-manager-admin-contracts/src/lib/attendance.models.ts
+++ b/libs/event-manager-admin-contracts/src/lib/attendance.models.ts
@@ -1,7 +1,13 @@
 import type { Event, MajorEvent } from './event.models';
 import type { Person } from './people.models';
 
-export type AttendanceCreationMethod = 'CSV_IMPORT' | 'MANUAL_INPUT' | 'SCANNER' | 'ONLINE_CODE' | 'UNKNOWN';
+export type AttendanceCreationMethod =
+  | 'CSV_IMPORT'
+  | 'EVENT_DUPLICATION'
+  | 'MANUAL_INPUT'
+  | 'SCANNER'
+  | 'ONLINE_CODE'
+  | 'UNKNOWN';
 export type AttendanceImportMatchType = 'IDENTITY_DOCUMENT' | 'EMAIL' | 'FULL_NAME';
 export type AttendanceCategory = 'NON_PAYING' | 'NON_SUBSCRIBED' | 'REGULAR' | 'UNKNOWN';
 export type SubscriptionStatus =

--- a/libs/event-manager-admin-contracts/src/lib/certificate.models.ts
+++ b/libs/event-manager-admin-contracts/src/lib/certificate.models.ts
@@ -107,6 +107,7 @@ export interface CertificateConfigClonePartsInput {
   recipientData?: boolean;
   activeState?: boolean;
   issuedPeople?: boolean;
+  manualPeople?: boolean;
 }
 
 export interface CertificateConfigCloneInput {

--- a/libs/event-manager-admin-contracts/src/lib/event.models.ts
+++ b/libs/event-manager-admin-contracts/src/lib/event.models.ts
@@ -286,6 +286,7 @@ export interface EventClonePartsInput {
   certificateConfig?: boolean;
   subscriptionSettings?: boolean;
   attendanceSettings?: boolean;
+  attendances?: boolean;
   place?: boolean;
   visibility?: boolean;
 }

--- a/libs/shared-data-types/src/lib/frontend-types.ts
+++ b/libs/shared-data-types/src/lib/frontend-types.ts
@@ -7,7 +7,13 @@ export type ContactType = 'EMAIL' | 'PHONE' | 'WHATSAPP' | 'OTHER';
 export type CertificateScope = 'MAJOR_EVENT' | 'EVENT_GROUP' | 'EVENT' | 'OTHER';
 export type CertificateIssuedTo = 'ATTENDEE' | 'LECTURER' | 'OTHER';
 export type SubscriptionCreationMethod = 'ADMIN_DASHBOARD' | 'SELF_SUBSCRIPTION' | 'UNKNOWN';
-export type AttendanceCreationMethod = 'CSV_IMPORT' | 'MANUAL_INPUT' | 'SCANNER' | 'ONLINE_CODE' | 'UNKNOWN';
+export type AttendanceCreationMethod =
+  | 'CSV_IMPORT'
+  | 'EVENT_DUPLICATION'
+  | 'MANUAL_INPUT'
+  | 'SCANNER'
+  | 'ONLINE_CODE'
+  | 'UNKNOWN';
 export type OfflineEventAttendanceSubmissionStatus = 'PENDING' | 'COMMITTED' | 'REJECTED';
 export type OfflineEventAttendanceResolutionIssue =
   | 'COLLECTION_WINDOW_EXPIRED'

--- a/libs/shared-data-types/src/lib/shared-data-types/certificate-inputs.ts
+++ b/libs/shared-data-types/src/lib/shared-data-types/certificate-inputs.ts
@@ -129,6 +129,9 @@ export class CertificateConfigClonePartsInput {
 
   @Field(() => Boolean, { nullable: true })
   issuedPeople?: boolean;
+
+  @Field(() => Boolean, { nullable: true })
+  manualPeople?: boolean;
 }
 
 @InputType()

--- a/libs/shared-data-types/src/lib/shared-data-types/enums.ts
+++ b/libs/shared-data-types/src/lib/shared-data-types/enums.ts
@@ -114,6 +114,7 @@ registerEnumType(PriceType, {
 
 export const AttendanceCreationMethod = {
   CSV_IMPORT: 'CSV_IMPORT',
+  EVENT_DUPLICATION: 'EVENT_DUPLICATION',
   MANUAL_INPUT: 'MANUAL_INPUT',
   SCANNER: 'SCANNER',
   ONLINE_CODE: 'ONLINE_CODE',

--- a/libs/shared-data-types/src/lib/shared-data-types/event-inputs.ts
+++ b/libs/shared-data-types/src/lib/shared-data-types/event-inputs.ts
@@ -242,6 +242,9 @@ export class EventClonePartsInput {
   attendanceSettings?: boolean;
 
   @Field(() => Boolean, { nullable: true })
+  attendances?: boolean;
+
+  @Field(() => Boolean, { nullable: true })
   place?: boolean;
 
   @Field(() => Boolean, { nullable: true })


### PR DESCRIPTION
Closes #278 
Closes #282 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Novos Recursos**
  * A clonagem de eventos agora permite copiar registros de presença.
  * A clonagem de configurações de certificados permite copiar listas manuais de pessoas.
  * Novas permissões e opções de seleção estão disponíveis nos diálogos de clonagem.

* **Melhorias**
  * Registros de presença clonados são identificados como “Duplicação de evento”.
  * Ações de clonagem passam a registrar informações de autoria e auditoria.
  * Categorias de presença são atualizadas após a cópia dos registros.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->